### PR TITLE
Fix owner-reminder after org transfer

### DIFF
--- a/.github/workflows/owner-reminder.yml
+++ b/.github/workflows/owner-reminder.yml
@@ -38,7 +38,7 @@ jobs:
           WEEK_END=$(date -u +%Y-%m-%d)
 
           # Collect templates from all platform integrations
-          BODY="@${OWNER} — the weekly retro runs tomorrow. Please paste your platform analytics below."
+          BODY="@evios — the weekly retro runs tomorrow. Please paste your platform analytics below."
           BODY="${BODY}"$'\n'
 
           for template in agent/integrations/*/templates/engagement-data.md; do
@@ -53,5 +53,5 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --title "Weekly Metrics (${WEEK_START} to ${WEEK_END})" \
             --label "metrics" \
-            --assignee "$OWNER" \
+            --assignee "evios" \
             --body "$BODY"


### PR DESCRIPTION
## Summary
- After repo transfer from `evios` to `AICMO` org, `github.repository_owner` became `AICMO`
- `--assignee "AICMO"` fails because orgs can't be assigned to issues
- `@AICMO` in issue body doesn't notify the actual owner
- Hardcoded `evios` username for assignee and mention

## Test plan
- [ ] Dispatch owner-reminder workflow after merge
- [ ] Verify issue is created and assigned to @evios