### PR TITLE
Fix auto-merge: switch to PAT_TOKEN

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -114,6 +114,6 @@ jobs:
         if: always() && (steps.review.outcome == 'success' || steps.retry.outcome == 'success')
         uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
         with:
-          token: ${{ secrets.AGENT_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN || secrets.AGENT_PAT || secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash


### PR DESCRIPTION
## Summary
- `AGENT_PAT` (set 2026-02-22) returns 401 Bad credentials, breaking the auto-merge step in every `agent-review` run.
- Switch primary token to org-level `PAT_TOKEN` (updated 2 days ago), with fallback to `AGENT_PAT` then `GITHUB_TOKEN`.

## Evidence
Run [25989413055](https://github.com/AICMO/Autonomous-Agent-X-Bluesky/actions/runs/25989413055/job/76392715308) and 8 other recent agent-review runs all fail at the same `gh pr merge --auto` call with:
```
non-200 OK status code: 401 Unauthorized body: "Bad credentials"
```

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger agent-review on the 9 open agent PRs (push empty commit or close/reopen) — confirm auto-merge step succeeds
- [ ] If PAT_TOKEN is not accessible from this repo (org secret not granted), revert and use a repo-level secret instead