### PR TITLE
Fix x.py: preserve queue on SpendCapReached quota errors

### DIFF
--- a/agent/integrations/x/plan.md
+++ b/agent/integrations/x/plan.md
@@ -1,5 +1,5 @@
 # X Platform Plan
-Last updated: 2026-05-12 (S926)
+Last updated: 2026-06-07 (owner: spend cap raised, x.py quota fix)
 
 ## Account Status
 - **Premium:** ACTIVE ($20/mo, activated 2026-03-01, Day 148)
@@ -9,9 +9,12 @@ Last updated: 2026-05-12 (S926)
 - **Reply failure rate:** 100% outbound (all skipped — see Week 9 retro); reply-to-own = 100% success
 
 ## SpendCap History
-- **2026-05-01 to 2026-05-11:** HTTP 403 SpendCapReached on all X posts (~11 days)
+- **2026-05-01 to 2026-05-11:** HTTP 403 SpendCapReached on all X posts (~11 days). 64 queued posts consumed (moved to skipped/) by old x.py behavior.
 - **2026-05-12:** RESOLVED — billing cycle reset. X posting resumed (confirmed via workflow logs: 3 posts at 04:34 UTC)
-- **If this happens again:** Owner must increase spend cap in X Developer Portal → App Settings → Usage & Limits
+- **2026-06-01 to 2026-06-07:** HTTP 403 SpendCapReached again (2nd consecutive month). 20 queued posts consumed (B67 posts 1-7 among them — never posted).
+- **2026-06-07:** RESOLVED EARLY — owner raised the spend cap in the X developer console (did not wait for the 2026-06-12 cycle reset).
+- **Fix shipped 2026-06-07:** x.py now raises `QuotaExceededError` on SpendCapReached/UsageCapExceeded 403s — halts the run and leaves the queue intact instead of moving files to skipped/. Workflow step fails visibly (Bluesky + commit steps still run via `!cancelled()`/`always()`).
+- **If this happens again:** Queue is safe (files stay pending). Owner must increase spend cap in X Developer Portal → App Settings → Usage & Limits. Watch for red "Post to X" steps in Actions — that's the new visible signal.
 
 ## Premium Features Available
 - Communities access (30,000x reach multiplier)

--- a/agent/integrations/x/x.py
+++ b/agent/integrations/x/x.py
@@ -173,6 +173,14 @@ class TemporaryError(Exception):
     pass
 
 
+class QuotaExceededError(Exception):
+    """Account-level quota block (e.g. monthly spend cap). Every request fails
+    until the billing cycle resets — halt the run and leave the queue intact.
+    Evidence: May+June 2026 SpendCapReached outages consumed 84 queued posts
+    because these 403s were treated as permanent failures."""
+    pass
+
+
 MAX_RETRIES = 4
 RETRY_DELAYS = [10, 30, 60, 120]  # longer backoff — CF challenges can clear after ~60s
 
@@ -247,6 +255,15 @@ def post_tweet(session, text, reply_to=None):
         return None
 
     log.info("Response: %s", json.dumps(data))
+
+    # Detect account-level quota blocks (403 SpendCapReached / UsageCapExceeded).
+    # These are temporary — the queue must stay intact, not be consumed file by file.
+    title = str(data.get("title", ""))
+    problem_type = str(data.get("type", ""))
+    if title in ("SpendCapReached", "UsageCapExceeded") or problem_type.endswith("/credits"):
+        reset_date = data.get("reset_date", "unknown")
+        raise QuotaExceededError(
+            f"{title or 'Quota exceeded'} — API blocked until {reset_date}: {data.get('detail', '')[:200]}")
 
     # Detect duplicate content rejection
     if response.status_code == 403:
@@ -391,7 +408,7 @@ def cmd_post(session, args):
             sys.exit(1)
         try:
             success = process_content(session, args.text)
-        except RateLimitError as e:
+        except (RateLimitError, QuotaExceededError) as e:
             log.warning("%s", e)
             sys.exit(1)
         sys.exit(0 if success else 1)
@@ -412,7 +429,7 @@ def cmd_post(session, args):
             sys.exit(1)
         try:
             success = process_content(session, content)
-        except RateLimitError as e:
+        except (RateLimitError, QuotaExceededError) as e:
             log.warning("%s", e)
             sys.exit(1)
         sys.exit(0 if success else 1)
@@ -471,6 +488,10 @@ def cmd_post(session, args):
             log.warning("Duplicate content, skipping: %s", e)
             filepath.rename(SKIPPED_DIR / filepath.name)
             continue
+        except QuotaExceededError as e:
+            log.error("%s", e)
+            log.info("Posted %d before quota block. Halting — all remaining files stay in queue until the cap resets.", posted)
+            sys.exit(0 if posted > 0 else 1)
         except RateLimitError as e:
             log.warning("%s", e)
             log.info("Posted %d before rate limit. Remaining files will be retried next run.", posted)

--- a/agent/state/current.md
+++ b/agent/state/current.md
@@ -1,5 +1,5 @@
 # Agent State
-Last Updated: 2026-06-07T05:40:00Z
+Last Updated: 2026-06-07T14:15:00Z (owner update: X spend cap raised, x.py quota fix shipped)
 Session: S1228
 PR Count Today: 12/15
 
@@ -10,23 +10,23 @@ PR Count Today: 12/15
 | Engagement Rate | 4.1% | >1% | Met | Healthy | Achieved |
 | Premium | ACTIVE (Day 187) | Active | Done | Since 2026-03-01 | - |
 
-## Queue Status (VERIFIED S1227 — filesystem)
+## Queue Status (VERIFIED 2026-06-07 — filesystem)
 | Platform | Count | Limit | Status |
 |----------|-------|-------|--------|
-| X | 0 | <15 | STUCK — SpendCapReached active until 2026-06-12. ZERO new X content. |
-| Bluesky | 7 | <10 | BS=6→7. BIP standalone written (bip-20260607-001). BLOCKED per outage corollary (BS=7 = zero content during X outage). |
+| X | 0 | <15 | UNBLOCKED — owner raised X API spend cap on 2026-06-07 (before the 2026-06-12 cycle reset). X posting can resume immediately. Verify with first post. |
+| Bluesky | 6 | <10 | bip-20260607-001 posted 2026-06-07 12:17 UTC. BS=6 — outage corollary no longer applies (X unblocked); normal BS rules resume. |
 
-## X Outage Tracker (active until 2026-06-12)
+## X Outage Tracker (ENDED 2026-06-07 — owner raised spend cap early)
 - BS standalones total: 41
 - BIP count: 9
 - Posts since last BIP: 0
 - BS pillar distribution: BIP=9(22%), P1=8(20%), P2=8(20%), P3=8(20%), P4=8(20%)
 - Outage start: 2026-06-01
-- Expected reset: 2026-06-12
+- Outage end: 2026-06-07 (owner raised spend cap in X developer console — did NOT wait for 2026-06-12 cycle reset)
 
-**BS=7 BLOCKED per outage corollary. Next when BS≤6: any pillar (BIP=22%, P1/P2/P3/P4=20% — BIP slightly over, write P1/P2/P3/P4 next).**
+**IMPORTANT — B67 posts 1-7 were NEVER POSTED.** The June 1-2 X files (bip-20260601-001, bip-20260602-001/002, p1-20260601-001, p1-20260602-001, p2-20260601-001, p3-20260601-001/002) hit SpendCapReached 403s and were moved to `agent/outputs/x/skipped/` by the old x.py behavior (fixed 2026-06-07 — quota errors now leave files in queue). The pillar files in skipped/ are evergreen and may be restored to the queue; the BIP files have stale day/session numbers and need rewriting.
 
-## B67 Burst (IN PROGRESS — 7/? X posts — PAUSED during SpendCap)
+## B67 Burst (IN PROGRESS — 7 posts written, 0 actually posted — see X Outage Tracker note)
 
 | Pillar | Posts | % | Target | Status |
 |--------|-------|---|--------|--------|
@@ -36,7 +36,8 @@ PR Count Today: 12/15
 | P4 | 1 | 14% | 15-20% | Marginal — back-half check fires at post 9 |
 | P3 | 1 | 14% | 20-25% | Below target — P3 back-half check fires at post 8 |
 
-**B67 PENDING (after SpendCap resets June 12):**
+**B67 RESUMES NOW (X unblocked 2026-06-07):**
+- First: decide whether to restore the burned posts 1-7 from `skipped/` (pillar files evergreen, BIP files stale — see X Outage Tracker note) or rewrite them.
 - Post 8: P3 (back-half check: P3=1 absolute → fires)
 - Post 9: P4 (back-half check: P4=1/8=12.5% < 15% → fires)
 - Post 10: P2 (P2=1/9=11% < 15% → fires)
@@ -52,9 +53,9 @@ PR Count Today: 12/15
 | P2 | 1 | 8% | 20-25% | Below target |
 
 ## Planned Steps
-1. **NEXT**: BS=7 — BLOCKED per outage corollary. Next when BS≤6: prefer P1/P2/P3/P4 (BIP=22%, slightly over target). posts-since-BIP=0.
-2. **THEN**: June 7 weekly retro will run (scheduled). Pre-retro complete and ready.
-3. **AFTER (June 12+)**: SpendCap resets. B67 resumes: Post 8=P3, Post 9=P4, Post 10=P2. New burst B68 starts after B67 completes.
+1. **NEXT**: X UNBLOCKED (owner raised cap 2026-06-07). Verify X posting works (first post through pipeline). Resume B67: restore evergreen pillar posts from skipped/ or write fresh. Post 8=P3, Post 9=P4, Post 10=P2.
+2. **THEN**: June 7 weekly retro will run (scheduled). Pre-retro complete and ready. Retro should cover: 84 posts burned across May+June SpendCap outages, x.py quota fix shipped 2026-06-07.
+3. **AFTER**: New burst B68 starts after B67 completes. BS=6 — normal BS rules resumed.
 
 ## Completed This Session (S1228)
 - Pre-retro updated with S1220-S1227 data: 41 standalones total, perfect 20% pillar balance, BIP counter validated (100% enforcement rate since S1198), Week 25 final metrics captured for June 7 retro.
@@ -81,9 +82,8 @@ PR Count Today: 12/15
 - Nothing new. Protocol working.
 
 ## Blockers
-1. **X SpendCap**: HTTP 403 until 2026-06-12. X=0 queue. Reset in ~5 days.
-2. **BS content**: BS=7 (outage corollary active). Next content when BS≤6. posts-since-BIP=0. Next: any pillar (BIP=22% slightly over, prefer P1/P2/P3/P4).
-3. **Communities (CRITICAL)**: Owner must join x.com/i/communities. 187+ days overdue. #1 growth lever.
+1. ~~X SpendCap~~ RESOLVED 2026-06-07: owner raised the spend cap in the X developer console (before the June 12 cycle reset). X posting can resume. Verify with first post — if 403 SpendCapReached recurs, the fixed x.py now halts and preserves the queue instead of consuming files.
+2. **Communities (CRITICAL)**: Owner must join x.com/i/communities. 187+ days overdue. #1 growth lever.
 
 ## Session History
 - (2026-06-07 S1228): Day 187. X=0 (SpendCap), BS=7 (blocked). Pre-retro updated (S1220-S1227 data: 41 standalones, 20% pillar balance, BIP counter validated). PR 12/15.


### PR DESCRIPTION
## Problem
X API 403 `SpendCapReached` responses were treated as permanent failures — each queued post was consumed (moved to `skipped/`) one file per workflow run, while the Actions runs showed green.

**Damage:** May 1–12 outage burned **64 posts**; June 1–7 outage burned **20 more** (including B67 posts 1–7, which the state file assumed were posted).

## Fix
- New `QuotaExceededError` in `agent/integrations/x/x.py`, raised when the response body has `title: SpendCapReached`/`UsageCapExceeded` or `type: .../problems/credits`
- Queue mode **halts on quota error and leaves all pending files in queue** (exit 1 when nothing posted → the "Post to X" step now fails *visibly* in Actions; Bluesky and commit steps still run via `!cancelled()` / `always()`)
- `--text` / `--file` modes catch the new error cleanly instead of tracebacking
- Duplicate-content 403s and validation failures still go to `skipped/` (correct — those are permanent)

## Verification
Replayed the exact SpendCapReached 403 body from the 2026-06-01 workflow logs against the patched script:
- queue stays intact (3/3 files), 0 moved to skipped/
- run halts after 1 API call (no pointless retries per file)
- exit code 1 → step fails visibly
- regression: duplicate-403 → `DuplicateContentError` (skipped/), successful post returns tweet id

## State updates (bundled)
- Owner raised the X spend cap on 2026-06-07 (before the June 12 cycle reset) — outage marked ENDED, blocker resolved, agent can resume X content now
- B67 posts 1–7 flagged as **never posted** (they sit in `skipped/`); pillar files are evergreen and restorable, BIP files have stale day/session numbers
- SpendCap history in `agent/integrations/x/plan.md` updated with both outages and the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)